### PR TITLE
Fix[#102](b) : RE:Fix[102](a)

### DIFF
--- a/scripts/modelscope/t2v_model.py
+++ b/scripts/modelscope/t2v_model.py
@@ -489,7 +489,7 @@ class CrossAttention(nn.Module):
         
         if has_torch2():
             out = F.scaled_dot_product_attention(
-                q, k, v, dropout_p=0.0, is_causal=False, attn_mask=mask
+                q, k, v, dropout_p=0.0, is_causal=False, attn_bias=mask
             )
         elif has_xformers():
             import xformers


### PR DESCRIPTION
reference [102a] :  https://github.com/deforum-art/sd-webui-text)2video/commit/67aaba9f0856589074384b5412c4553647f02d22 :: --attn_mask++attn_bias    

Fixes second source of : memory_efficient_attention() got an unexpected keyword argument 'mask' errors. 

102 was closed, but issue persisted,  l:492  had variable attn_mask instead of attn_bias.   Changing this and the error is no longer presenting.  