### PR TITLE
Fix[122] :: Exception occurred: 'NoneType' object has no attribute 'name'

### DIFF
--- a/scripts/modelscope/process_modelscope.py
+++ b/scripts/modelscope/process_modelscope.py
@@ -139,7 +139,7 @@ def process_modelscope(args_dict):
     for batch in pbar:
 
         # TODO: move to a separate function
-        if args.inpainting_frames > 0:
+        if  args.inpainting_frames > 0 and hasattr(args.inpainting_image, "name"):
             keys = T2VAnimKeys(SimpleNamespace(**{'max_frames':args.frames, 'inpainting_weights':args.inpainting_weights}), args.seed, args.inpainting_frames)
             images=[]
             print("Received an image for inpainting", args.inpainting_image.name)


### PR DESCRIPTION
Per: https://github.com/deforum-art/sd-webui-text2video/issues/122

process_modelscope.py:: inpainting_frames->args.inpainting_frames  && hasattr(args.inpainting_image, "name")
Fixed two issues that saw similar presentation: 

1:  inpainting_frames did not have args. prepended, necessary after the move of this function from text2vid.py.    
2:  added a check for attribute name in args.inpainting_image,   This resolves the issue of having frames nonzero in the img2text section without an image loaded resulting in the attribute not existing for args.inpainting_image.name

This should fix those two issues.  