### PR TITLE
Prepend submodule imports with `script.`

### DIFF
--- a/scripts/api_t2v.py
+++ b/scripts/api_t2v.py
@@ -28,10 +28,10 @@ from fastapi import FastAPI, Query, Request, UploadFile
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-from t2v_helpers.video_audio_utils import find_ffmpeg_binary
-from t2v_helpers.general_utils import get_t2v_version
-from t2v_helpers.args import T2VArgs_sanity_check, T2VArgs, T2VOutputArgs
-from t2v_helpers.render import run
+from scripts.t2v_helpers.video_audio_utils import find_ffmpeg_binary
+from scripts.t2v_helpers.general_utils import get_t2v_version
+from scripts.t2v_helpers.args import T2VArgs_sanity_check, T2VArgs, T2VOutputArgs
+from scripts.t2v_helpers.render import run
 import uuid
 
 logger = logging.getLogger(__name__)

--- a/scripts/modelscope/process_modelscope.py
+++ b/scripts/modelscope/process_modelscope.py
@@ -2,8 +2,8 @@
 from base64 import b64encode
 from tqdm import tqdm
 from PIL import Image
-from modelscope.t2v_pipeline import TextToVideoSynthesis, tensor2vid
-from t2v_helpers.key_frames import T2VAnimKeys #TODO: move to deforum_tools
+from scripts.modelscope.t2v_pipeline import TextToVideoSynthesis, tensor2vid
+from scripts.t2v_helpers.key_frames import T2VAnimKeys #TODO: move to deforum_tools
 from pathlib import Path
 import numpy as np
 import torch
@@ -11,11 +11,11 @@ import cv2
 import gc
 import modules.paths as ph
 from types import SimpleNamespace
-from t2v_helpers.general_utils import get_t2v_version
+from scripts.t2v_helpers.general_utils import get_t2v_version
 import time, math
-from t2v_helpers.video_audio_utils import ffmpeg_stitch_video, get_quick_vid_info, vid2frames, duplicate_pngs_from_folder, clean_folder_name
-from t2v_helpers.args import get_outdir, process_args
-import t2v_helpers.args as t2v_helpers_args
+from scripts.t2v_helpers.video_audio_utils import ffmpeg_stitch_video, get_quick_vid_info, vid2frames, duplicate_pngs_from_folder, clean_folder_name
+from scripts.t2v_helpers.args import get_outdir, process_args
+import scripts.t2v_helpers.args as t2v_helpers_args
 from modules import shared, sd_hijack, lowvram
 from modules.shared import opts, devices, state
 import os

--- a/scripts/t2v_helpers/args.py
+++ b/scripts/t2v_helpers/args.py
@@ -1,7 +1,7 @@
 import gradio as gr
 from types import SimpleNamespace
-from t2v_helpers.video_audio_utils import find_ffmpeg_binary
-from modelscope.t2v_model import has_torch2
+from scripts.t2v_helpers.video_audio_utils import find_ffmpeg_binary
+from scripts.modelscope.t2v_model import has_torch2
 import os
 from modules.shared import opts
 

--- a/scripts/t2v_helpers/render.py
+++ b/scripts/t2v_helpers/render.py
@@ -1,13 +1,13 @@
 import traceback
-from modelscope.process_modelscope import process_modelscope
-import modelscope.process_modelscope as pm
-from videocrafter.process_videocrafter import process_videocrafter
+from scripts.modelscope.process_modelscope import process_modelscope
+import scripts.modelscope.process_modelscope as pm
+from scripts.videocrafter.process_videocrafter import process_videocrafter
 from modules.shared import opts
 from .error_hardcode import get_error
 from modules import lowvram, devices, sd_hijack
-import logging 
+import logging
 import gc
-import t2v_helpers.args as t2v_helpers_args
+import scripts.t2v_helpers.args as t2v_helpers_args
 
 def run(*args):
     dataurl = get_error()

--- a/scripts/text2vid.py
+++ b/scripts/text2vid.py
@@ -13,9 +13,9 @@ for basedir in basedirs:
 import gradio as gr
 from modules import script_callbacks, shared
 from modules.shared import cmd_opts, opts
-from t2v_helpers.render import run
-import t2v_helpers.args as args
-from t2v_helpers.args import setup_text2video_settings_dictionary
+from scripts.t2v_helpers.render import run
+import scripts.t2v_helpers.args as args
+from scripts.t2v_helpers.args import setup_text2video_settings_dictionary
 from webui import wrap_gradio_gpu_call
 
 def process(*args):

--- a/scripts/videocrafter/lvdm/models/autoencoder.py
+++ b/scripts/videocrafter/lvdm/models/autoencoder.py
@@ -4,9 +4,9 @@ import torch.nn.functional as F
 import os
 from einops import rearrange
 
-from videocrafter.lvdm.models.modules.autoencoder_modules import Encoder, Decoder
-from videocrafter.lvdm.models.modules.distributions import DiagonalGaussianDistribution
-from videocrafter.lvdm.utils.common_utils import instantiate_from_config
+from scripts.videocrafter.lvdm.models.modules.autoencoder_modules import Encoder, Decoder
+from scripts.videocrafter.lvdm.models.modules.distributions import DiagonalGaussianDistribution
+from scripts.videocrafter.lvdm.utils.common_utils import instantiate_from_config
 
 class AutoencoderKL(pl.LightningModule):
     def __init__(self,

--- a/scripts/videocrafter/lvdm/models/ddpm3d.py
+++ b/scripts/videocrafter/lvdm/models/ddpm3d.py
@@ -15,11 +15,11 @@ import pytorch_lightning as pl
 from torchvision.utils import make_grid
 from torch.optim.lr_scheduler import LambdaLR
 from pytorch_lightning.utilities import rank_zero_only
-from videocrafter.lvdm.models.modules.distributions import normal_kl, DiagonalGaussianDistribution
-from videocrafter.lvdm.models.modules.util import make_beta_schedule, extract_into_tensor, noise_like
-from videocrafter.lvdm.models.modules.lora import inject_trainable_lora
-from videocrafter.lvdm.samplers.ddim import DDIMSampler
-from videocrafter.lvdm.utils.common_utils import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config, check_istarget
+from scripts.videocrafter.lvdm.models.modules.distributions import normal_kl, DiagonalGaussianDistribution
+from scripts.videocrafter.lvdm.models.modules.util import make_beta_schedule, extract_into_tensor, noise_like
+from scripts.videocrafter.lvdm.models.modules.lora import inject_trainable_lora
+from scripts.videocrafter.lvdm.samplers.ddim import DDIMSampler
+from scripts.videocrafter.lvdm.utils.common_utils import log_txt_as_img, exists, default, ismap, isimage, mean_flat, count_params, instantiate_from_config, check_istarget
 
 
 def disabled_train(self, mode=True):

--- a/scripts/videocrafter/lvdm/models/modules/adapter.py
+++ b/scripts/videocrafter/lvdm/models/modules/adapter.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 from collections import OrderedDict
-from videocrafter.lvdm.models.modules.util import (
+from scripts.videocrafter.lvdm.models.modules.util import (
     zero_module,
     conv_nd,
     avg_pool_nd

--- a/scripts/videocrafter/lvdm/models/modules/attention_temporal.py
+++ b/scripts/videocrafter/lvdm/models/modules/attention_temporal.py
@@ -11,7 +11,7 @@ try:
 except:
     XFORMERS_IS_AVAILBLE = False
 
-from videocrafter.lvdm.models.modules.util import (
+from scripts.videocrafter.lvdm.models.modules.util import (
     GEGLU,
     exists,
     default,

--- a/scripts/videocrafter/lvdm/models/modules/openaimodel3d.py
+++ b/scripts/videocrafter/lvdm/models/modules/openaimodel3d.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from omegaconf.listconfig import ListConfig
 
-from videocrafter.lvdm.models.modules.util import (
+from scripts.videocrafter.lvdm.models.modules.util import (
     checkpoint,
     conv_nd,
     linear,

--- a/scripts/videocrafter/lvdm/models/modules/util.py
+++ b/scripts/videocrafter/lvdm/models/modules/util.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 from einops import repeat
 import torch.nn.functional as F
 
-from videocrafter.lvdm.utils.common_utils import instantiate_from_config
+from scripts.videocrafter.lvdm.utils.common_utils import instantiate_from_config
 
 
 def make_beta_schedule(schedule, n_timestep, linear_start=1e-4, linear_end=2e-2, cosine_s=8e-3):

--- a/scripts/videocrafter/lvdm/samplers/ddim.py
+++ b/scripts/videocrafter/lvdm/samplers/ddim.py
@@ -7,7 +7,7 @@ from tqdm import tqdm
 from modules.shared import state
 from modules.sd_samplers_common import InterruptedException
 
-from videocrafter.lvdm.models.modules.util import make_ddim_sampling_parameters, make_ddim_timesteps, noise_like
+from scripts.videocrafter.lvdm.models.modules.util import make_ddim_sampling_parameters, make_ddim_timesteps, noise_like
 
 
 class DDIMSampler(object):

--- a/scripts/videocrafter/sample_text2video.py
+++ b/scripts/videocrafter/sample_text2video.py
@@ -9,11 +9,11 @@ from omegaconf import OmegaConf
 import torch.distributed as dist
 from pytorch_lightning import seed_everything
 
-from videocrafter.lvdm.samplers.ddim import DDIMSampler
-from videocrafter.lvdm.utils.common_utils import str2bool
-from videocrafter.lvdm.utils.dist_utils import setup_dist, gather_data
-from videocrafter.lvdm.utils.saving_utils import npz_to_video_grid, npz_to_imgsheet_5d
-from videocrafter.sample_utils import load_model, get_conditions, make_model_input_shape, torch_to_np
+from scripts.videocrafter.lvdm.samplers.ddim import DDIMSampler
+from scripts.videocrafter.lvdm.utils.common_utils import str2bool
+from scripts.videocrafter.lvdm.utils.dist_utils import setup_dist, gather_data
+from scripts.videocrafter.lvdm.utils.saving_utils import npz_to_video_grid, npz_to_imgsheet_5d
+from scripts.videocrafter.sample_utils import load_model, get_conditions, make_model_input_shape, torch_to_np
 
 
 # ------------------------------------------------------------------------------------------

--- a/scripts/videocrafter/sample_utils.py
+++ b/scripts/videocrafter/sample_utils.py
@@ -2,8 +2,8 @@ import os
 import torch
 from PIL import Image
 
-from videocrafter.lvdm.models.modules.lora import net_load_lora
-from videocrafter.lvdm.utils.common_utils import instantiate_from_config
+from scripts.videocrafter.lvdm.models.modules.lora import net_load_lora
+from scripts.videocrafter.lvdm.utils.common_utils import instantiate_from_config
 
 
 # ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes extension failing to load due to t2v_helper module (or other submodules) not being found by Python