### PR TITLE
Fix for 243

### DIFF
--- a/javascript/t2v_progressbar.js
+++ b/javascript/t2v_progressbar.js
@@ -14,3 +14,8 @@ function submit_txt2vid(){
 
     return res
 }
+
+function setSubmitButtonsVisibility(tabname, showInterrupt, showSkip, showInterrupting) {
+    gradioApp().getElementById(tabname + '_interrupt').style.display = showInterrupt ? "block" : "none";
+    gradioApp().getElementById(tabname + '_skip').style.display = showSkip ? "block" : "none";
+}

--- a/scripts/modelscope/clip_hardcode.py
+++ b/scripts/modelscope/clip_hardcode.py
@@ -150,7 +150,7 @@ class FrozenOpenCLIPEmbedder(torch.nn.Module):
         Returns the list and the total number of tokens in the prompt.
         """
 
-        if opts.enable_emphasis:
+        if hasattr(opts, 'enable_emphasis') and opts.enable_emphasis:
             parsed = prompt_parser.parse_prompt_attention(line)
         else:
             parsed = [[line, 1.0]]


### PR DESCRIPTION
Fix for issues reported in https://github.com/kabachuha/sd-webui-text2video/issues/243, both the original issue (UI does nothing when you click "generate") and a secondary issue where an exception is thrown when using ModelScope.